### PR TITLE
Basic update for blaze support

### DIFF
--- a/progress.coffee
+++ b/progress.coffee
@@ -121,13 +121,16 @@ callbacks =
 		# Take the options from the route, if any
 		IronRouterProgress.start @options.progress or {}
 		@
-	before : ->
+	before : (pause)->
 		action = 'before'
 		if @ready()
 			IronRouterProgress.done()
 		else
 			IronRouterProgress.progress()
-			@stop()
+			if _.isFunction(pause)
+        pause()
+      else
+        this.stop()
 		@
 	after : ->
 		IronRouterProgress.done()


### PR DESCRIPTION
Hey, I'm just getting Discover Meteor ready for the imminent Blaze (Meteor UI / Shark) release.

Iron Router also is getting ready for a similar release. I think the only way it directly affects this package is that `this.stop()` has been replaced by `pause()`. I've made the obvious change in the `before` filter you setup, but I guess there's a more subtle one in the way you override `this.stop()`. I'm not sure what the best approach is there.

P.S. Have you considered calling `Router.before(..)` etc, rather than writing in a `before` filter for every route?
