### PR TITLE
Suppress `iron:router` warning - wrap on-before-action in a `Tracker.autorun`

### DIFF
--- a/package.js
+++ b/package.js
@@ -15,6 +15,7 @@ Package.onUse(function (api) {
 		'templating',
 		'jquery',
 		'reactive-var',
+		'tracker',
 		'iron:router@1.0.0',
 		'iron:layout@1.0.0'
 	], 'client');

--- a/progress.coffee
+++ b/progress.coffee
@@ -150,11 +150,13 @@ Template.__IronRouterProgress__.created = ->
 
 	Router.onBeforeAction ->
 		debug 'IR:before'
-		if @ready()
-			self.functions.done()
-			self.functions.stop()
-		else
-			self.functions.progress()
+		Tracker.autorun ()=>
+			if @ready()
+				self.functions.done()
+				self.functions.stop()
+			else
+				self.functions.progress()
+			return
 		@next()
 		@
 
@@ -190,7 +192,7 @@ Template.__IronRouterProgressDefault__.helpers
 		classes.join ' '
 	cssStyle : ->
 		styles = []
-		
+
 		styles.push "width:#{@percent.get()}%" if @percent.get()
 
 		styles.join ';'


### PR DESCRIPTION
Fixes bug in latest iron:router / meteor:

```
Exception in callback of async function: Error: 

You called wait() after calling ready() inside the same computation tree.

You can fix this problem in two possible ways:

1) Put all of your wait() calls before any ready() calls.
2) Put your ready() call in its own computation with Deps.autorun.
```
